### PR TITLE
P22-803 : Added Poetry dependency manager

### DIFF
--- a/.github/workflows/python-quality-checks.yml
+++ b/.github/workflows/python-quality-checks.yml
@@ -1,4 +1,4 @@
-name: Python Pipenv
+name: Python Quality Checks
 
 on:
   workflow_call:
@@ -20,7 +20,8 @@ jobs:
       should-skip: ${{ steps.skip-check.outputs.should_skip }}
 
     steps:
-      - id: skip-check
+      - name: Skip Check
+        id: skip-check
         uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: same_content
@@ -38,9 +39,36 @@ jobs:
             ]
           skip_after_successful_duplicate: true
 
+  dependencies-manager:
+    name: Dependencies manager finder
+    needs: [ pre-checks ]
+    if: ${{ needs.pre_checks.outputs.should-skip != 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      dm: ${{ steps.dependencies-manager.outputs.dm }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Search Poetry
+        id: search-poetry
+        shell: bash
+        run: echo "poetry-str=$(cat .tool-versions | grep poetry | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - name: Check if poetry
+        id: check-if-poetry
+        shell: bash
+        run: echo "use-poetry=$(expr '${{ steps.search-poetry.outputs.poetry-str }}' == 'poetry')" >> $GITHUB_OUTPUT
+
+      - name: Dependecies Manager
+        id: dependencies-manager
+        shell: bash
+        run: if [[ ${{ steps.check-if-poetry.outputs.use-poetry }} == 1 ]]; then echo 'dm=poetry'; else echo 'dm=pipenv'; fi >> $GITHUB_OUTPUT
+
   setup:
     name: Setup
-    needs: [pre-checks]
+    needs: [ pre-checks ]
     if: ${{ needs.pre_checks.outputs.should-skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +80,7 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    needs: [setup]
+    needs: [ setup, dependencies-manager ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -63,11 +91,11 @@ jobs:
 
       - name: Run pytest
         working-directory: ${{ inputs.working-directory }}
-        run: pipenv run pytest -v
+        run: ${{ needs.dependencies-manager.outputs.dm }} run pytest -v
 
   type-check:
     name: Type check
-    needs: [setup]
+    needs: [ setup, dependencies-manager ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,11 +106,11 @@ jobs:
 
       - name: Run pytype
         working-directory: ${{ inputs.working-directory }}
-        run: pipenv run pytype
+        run: ${{ needs.dependencies-manager.outputs.dm }} run pytype
 
   code-style:
     name: Code style
-    needs: [setup]
+    needs: [ setup, dependencies-manager ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -93,4 +121,4 @@ jobs:
 
       - name: Run pycodestyle
         working-directory: ${{ inputs.working-directory }}
-        run: pipenv run pycodestyle --statistics --count
+        run: ${{ needs.dependencies-manager.outputs.dm }} run pycodestyle --statistics --count


### PR DESCRIPTION
Proposition pour ajouter la possibilité d'utiliser le gestionnaire de dépendences Poetry en plus de Pipenv.

Le fichier `python-pipenv.yml` devient donc `python-quality-checks.yml`. C'est un breaking change, il faudra passer à la version v4.

On vient ici ajouter une petite recherche dans `.tool-versions` afin de voir si le gestionnaire 'poetry' est présent. Ensuite, selon le cas, on vient substituer les appels pour lancer les checks à l'aide de `pipenv run ...` ou bien de `poetry run ...`

J'ai fait l'essai en pointant sur la branche [P22-802](https://github.com/equisoft-actions/setup-python/pull/10) de setup-python et ça fonctionne tant pour pipenv que poetry.