### PR TITLE
P22-856: Ruff linter

### DIFF
--- a/.github/workflows/python-quality-checks.yml
+++ b/.github/workflows/python-quality-checks.yml
@@ -98,28 +98,4 @@ jobs:
 
       - name: Run codestyle
         working-directory: ${{ inputs.working-directory }}
-        run: ${{ needs.setup.outputs.dependencies-manager }} run ruff check --select E --select W --statistics ./
-
-  future-code-style:
-    name: Future code style
-    needs: [ setup ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: equisoft-actions/setup-python@v1
-
-      - name: Run future codestyle
-        id: run_future_codestyle
-        working-directory: ${{ inputs.working-directory }}
-        run: ${{ needs.setup.outputs.dependencies-manager }} run ruff check --select ANN --select F --select I --select N --select PD --ignore ANN101 --ignore ANN102 --ignore ANN401 --ignore PD015 --ignore PD901 --statistics ./
-        continue-on-error: true
-
-      - name: generate exception
-        if: ${{ steps.run_future_codestyle.outcome == 'failure' }}
-        run: | 
-          text="The code does not comply to the future code style rules, it will become mandatory"
-          echo "::error ::$text"
-          exit 1
+        run: ${{ needs.setup.outputs.dependencies-manager }} run ruff check --extend-select E --extend-select W --statistics ./

--- a/.github/workflows/python-quality-checks.yml
+++ b/.github/workflows/python-quality-checks.yml
@@ -98,4 +98,4 @@ jobs:
 
       - name: Run codestyle
         working-directory: ${{ inputs.working-directory }}
-        run: ${{ needs.setup.outputs.dependencies-manager }} run ruff check --extend-select E --extend-select W --statistics ./
+        run: ${{ needs.setup.outputs.dependencies-manager }} run ruff check --select ANN --select E --select F --select I --select N --select PD --select W --ignore ANN101 --ignore ANN102 --ignore ANN401 --ignore PD015 --ignore PD901 --statistics ./

--- a/.github/workflows/python-quality-checks.yml
+++ b/.github/workflows/python-quality-checks.yml
@@ -96,6 +96,30 @@ jobs:
       - name: Setup Python
         uses: equisoft-actions/setup-python@v1
 
-      - name: Run pycodestyle
+      - name: Run codestyle
         working-directory: ${{ inputs.working-directory }}
-        run: ${{ needs.setup.outputs.dependencies-manager }} run pycodestyle --statistics --count
+        run: ${{ needs.setup.outputs.dependencies-manager }} run ruff check --select E --select W --statistics ./
+
+  future-code-style:
+    name: Future code style
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: equisoft-actions/setup-python@v1
+
+      - name: Run future codestyle
+        id: run_future_codestyle
+        working-directory: ${{ inputs.working-directory }}
+        run: ${{ needs.setup.outputs.dependencies-manager }} run ruff check --select ANN --select F --select I --select N --select PD --ignore ANN101 --ignore ANN102 --ignore ANN401 --ignore PD015 --ignore PD901 --statistics ./
+        continue-on-error: true
+
+      - name: generate exception
+        if: ${{ steps.run_future_codestyle.outcome == 'failure' }}
+        run: | 
+          text="The code does not comply to the future code style rules, it will become mandatory"
+          echo "::error ::$text"
+          exit 1


### PR DESCRIPTION
Passage au linter [Ruff](https://beta.ruff.rs/docs/).

La job `code-style` est maintenue. On y utilise maintenant Ruff avec seulement le sous-ensemble de règles correspondant à celles qui étaient couvertes par pycodestyle.

On ajoute un nouvel ensemble de règles via la job `future-code-style`. 
Ces règles ne devraient pas être bloquantes dans le workflow. Éventuellement, lorsque les projets seront prêts, on pourra en transférer vers `code-style`.